### PR TITLE
Allow missing “assets” key in sea-config.json

### DIFF
--- a/src/node_sea.cc
+++ b/src/node_sea.cc
@@ -402,12 +402,7 @@ std::optional<SeaConfig> ParseSingleExecutableConfig(
 
   std::optional<std::unordered_map<std::string, std::string>> assets_opt =
       parser.GetTopLevelDictOfStrings("assets");
-  if (!assets_opt.has_value()) {
-    FPrintF(stderr,
-            "\"assets\" field of %s is not a map of strings\n",
-            config_path);
-    return std::nullopt;
-  } else if (!assets_opt.value().empty()) {
+  if (assets_opt.has_value() && !assets_opt.value().empty()) {
     result.flags |= SeaFlags::kIncludeAssets;
     result.assets = std::move(assets_opt.value());
   }


### PR DESCRIPTION
The current tests break because they are missing the *assets* field.

